### PR TITLE
feat: 단국대 학생 정보 및 유저 Entity에 나이, 성별 정보 추가

### DIFF
--- a/src/main/java/com/dku/council/domain/batch/DkuStudentAgeScheduler.java
+++ b/src/main/java/com/dku/council/domain/batch/DkuStudentAgeScheduler.java
@@ -1,0 +1,23 @@
+package com.dku.council.domain.batch;
+
+import com.dku.council.domain.user.model.entity.User;
+import com.dku.council.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DkuStudentAgeScheduler {
+
+    private final UserRepository userRepository;
+
+    // 매년 0시 0분 0초에 실행
+
+    @Scheduled(cron = "0 0 0 1 1 *")
+    public void dkuStudentAgeScheduler() {
+        userRepository.findAll().forEach(User::updateAge);
+    }
+}

--- a/src/main/java/com/dku/council/domain/user/model/DkuUserInfo.java
+++ b/src/main/java/com/dku/council/domain/user/model/DkuUserInfo.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 public class DkuUserInfo {
     private final String studentName;
     private final String studentId;
+    private final String age;
+    private final String gender;
     private final int yearOfAdmission;
     private final String studentState;
 
@@ -18,6 +20,8 @@ public class DkuUserInfo {
     public DkuUserInfo(StudentInfo info) {
         this.studentName = info.getStudentName();
         this.studentId = info.getStudentId();
+        this.age = info.getAge();
+        this.gender = info.getGender();
         this.yearOfAdmission = info.getYearOfAdmission();
         this.studentState = info.getStudentState();
         this.majorName = info.getMajorName();

--- a/src/main/java/com/dku/council/domain/user/model/UserInfo.java
+++ b/src/main/java/com/dku/council/domain/user/model/UserInfo.java
@@ -17,6 +17,8 @@ public class UserInfo {
     private final MajorInfo major;
     private final int yearOfAdmission;
     private final String academicStatus;
+    private final String age;
+    private final String gender;
     private final UserStatus status;
 
     public UserInfo(User user) {
@@ -27,6 +29,8 @@ public class UserInfo {
         this.major = new MajorInfo(user.getMajor());
         this.yearOfAdmission = user.getYearOfAdmission();
         this.academicStatus = user.getAcademicStatus();
+        this.age = user.getAge();
+        this.gender = user.getGender();
         this.status = user.getStatus();
     }
 

--- a/src/main/java/com/dku/council/domain/user/model/dto/request/RequestVerifyEmailCodeDto.java
+++ b/src/main/java/com/dku/council/domain/user/model/dto/request/RequestVerifyEmailCodeDto.java
@@ -27,6 +27,12 @@ public class RequestVerifyEmailCodeDto {
     private final String academicStatus;
 
     @NotBlank
+    private final String age;
+
+    @NotBlank
+    private final String gender;
+
+    @NotBlank
     @Pattern(regexp = "^.{5}$", message = "이메일 코드는 5자리 입니다.")
     private final String emailCode;
 }

--- a/src/main/java/com/dku/council/domain/user/model/dto/response/ResponseScrappedStudentInfoDto.java
+++ b/src/main/java/com/dku/council/domain/user/model/dto/response/ResponseScrappedStudentInfoDto.java
@@ -8,11 +8,15 @@ public class ResponseScrappedStudentInfoDto {
 
     private final String studentName;
     private final String studentId;
+    private final String age;
+    private final String gender;
     private final String major;
 
     public ResponseScrappedStudentInfoDto(DkuUserInfo info) {
         this.studentName = info.getStudentName();
         this.studentId = info.getStudentId();
+        this.age = info.getAge();
+        this.gender = info.getGender();
         this.major = info.getMajorName();
     }
 }

--- a/src/main/java/com/dku/council/domain/user/model/dto/response/ResponseUserInfoDto.java
+++ b/src/main/java/com/dku/council/domain/user/model/dto/response/ResponseUserInfoDto.java
@@ -10,6 +10,8 @@ public class ResponseUserInfoDto {
     private final String studentId;
     private final String username;
     private final String nickname;
+    private final String age;
+    private final String gender;
     private final String yearOfAdmission;
     private final String major;
     private final String department;

--- a/src/main/java/com/dku/council/domain/user/model/entity/User.java
+++ b/src/main/java/com/dku/council/domain/user/model/entity/User.java
@@ -47,6 +47,10 @@ public class User extends BaseEntity {
     @Column(length = 20)
     private String nickname;
 
+    private String age;
+
+    private String gender;
+
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "major_id")
     private Major major;
@@ -76,6 +80,8 @@ public class User extends BaseEntity {
                  @NonNull String phone,
                  @NonNull String nickname,
                  @NonNull String academicStatus,
+                 @NonNull String age,
+                 @NonNull String gender,
                  Integer yearOfAdmission,
                  UserStatus status,
                  UserRole role) {
@@ -86,6 +92,8 @@ public class User extends BaseEntity {
         this.phone = phone;
         this.nickname = nickname;
         this.academicStatus = academicStatus;
+        this.age = age;
+        this.gender = gender;
         this.yearOfAdmission = yearOfAdmission;
         this.status = status;
         this.userRole = role;
@@ -146,6 +154,16 @@ public class User extends BaseEntity {
     }
 
     /**
+     * 나이를 변경합니다.
+     * User정보 캐시를 삭제하기위해 {@link UserInfoService}.invalidateUserInfo를 호출해야 합니다.
+     *
+     * @param age 나이
+     */
+    public void changeAge(String age) {
+        this.age = age;
+    }
+
+    /**
      * 공통 User 정보를 수정합니다.
      * User정보 캐시를 삭제하기위해 {@link UserInfoService}.invalidateUserInfo를 호출해야 합니다.
      *
@@ -155,12 +173,14 @@ public class User extends BaseEntity {
      * @param yearOfAdmission 입학년도
      * @param studentState    학적상태
      */
-    public void changeGenericInfo(String studentId, String studentName, Major major, int yearOfAdmission, String studentState) {
+    public void changeGenericInfo(String studentId, String studentName, Major major, int yearOfAdmission, String studentState, String age, String gender) {
         this.studentId = studentId;
         this.name = studentName;
         this.major = major;
         this.yearOfAdmission = yearOfAdmission;
         this.academicStatus = studentState;
+        this.age = age;
+        this.gender = gender;
     }
 
     /**
@@ -172,6 +192,8 @@ public class User extends BaseEntity {
         this.name = "";
         this.phone = "";
         this.nickname = "";
+        this.age = "";
+        this.gender = "";
         this.password = "";
     }
 
@@ -180,5 +202,15 @@ public class User extends BaseEntity {
      */
     public void changeIsDkuChecked() {
         this.isDkuChecked = !this.isDkuChecked;
+    }
+
+
+    /**
+     * 매년 1월 1일 사용자들의 나이 1을 증가시킵니다.
+     */
+    public void updateAge() {
+        int age = Integer.parseInt(this.age);
+        age++;
+        this.age = String.valueOf(age);
     }
 }

--- a/src/main/java/com/dku/council/domain/user/service/DKUAuthService.java
+++ b/src/main/java/com/dku/council/domain/user/service/DKUAuthService.java
@@ -93,7 +93,7 @@ public class DKUAuthService {
      * @param dto 요청 dto
      * @return 학생 인증 결과 dto
      */
-    @Transactional(readOnly = true)
+    @Transactional
     public ResponseScrappedStudentInfoDto updateDKUStudent(Long userId, RequestDkuStudentDto dto) {
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         DkuUserInfo info = retrieveDkuUserInfo(dto.getDkuStudentId(), dto.getDkuPassword());
@@ -105,7 +105,9 @@ public class DKUAuthService {
                 info.getStudentName(),
                 major,
                 info.getYearOfAdmission(),
-                info.getStudentState());
+                info.getStudentState(),
+                info.getAge(),
+                info.getGender());
 
         userInfoService.invalidateUserInfo(userId);
         return new ResponseScrappedStudentInfoDto(info);

--- a/src/main/java/com/dku/council/domain/user/service/DkuEmailService.java
+++ b/src/main/java/com/dku/council/domain/user/service/DkuEmailService.java
@@ -91,8 +91,8 @@ public class DkuEmailService {
 
         Major major = majorRepository.findById(dto.getMajorId())
                 .orElseThrow(MajorNotFoundException::new);
-        DkuUserInfo info = new DkuUserInfo(dto.getStudentName(), dto.getStudentId(), dto.getYearOfAdmission(),
-                dto.getAcademicStatus(), major.getName(), major.getDepartment());
+        DkuUserInfo info = new DkuUserInfo(dto.getStudentName(), dto.getStudentId(), dto.getAge(), dto.getGender(),
+                dto.getYearOfAdmission(), dto.getAcademicStatus(), major.getName(), major.getDepartment());
 
         dkuAuthRepository.setAuthPayload(signupToken, DKU_AUTH_NAME, info, now);
 

--- a/src/main/java/com/dku/council/domain/user/service/SignupService.java
+++ b/src/main/java/com/dku/council/domain/user/service/SignupService.java
@@ -54,7 +54,7 @@ public class SignupService {
             user.changePassword(encryptedPassword);
             user.changeIsDkuChecked();
             user.changeGenericInfo(studentInfo.getStudentId(), studentInfo.getStudentName(), major,
-                    studentInfo.getYearOfAdmission(), studentInfo.getStudentState());
+                    studentInfo.getYearOfAdmission(), studentInfo.getStudentState(), studentInfo.getAge(), studentInfo.getGender());
             userInfoService.invalidateUserInfo(user.getId());
         } else {
             User user = User.builder()
@@ -64,6 +64,8 @@ public class SignupService {
                     .nickname(dto.getNickname())
                     .phone(phone)
                     .major(major)
+                    .age(studentInfo.getAge())
+                    .gender(studentInfo.getGender())
                     .yearOfAdmission(studentInfo.getYearOfAdmission())
                     .academicStatus(studentInfo.getStudentState())
                     .status(UserStatus.ACTIVE)

--- a/src/main/java/com/dku/council/domain/user/service/UserInfoService.java
+++ b/src/main/java/com/dku/council/domain/user/service/UserInfoService.java
@@ -43,8 +43,9 @@ public class UserInfoService {
         Long likedPostCount = likeService.getCountOfLikedElements(userId, LikeTarget.POST);
 
         return new ResponseUserInfoDto(user.getStudentId(), user.getName(),
-                user.getNickname(), year, major.getName(), major.getDepartment(),
-                phoneNumber, writePostCount, commentedPostCount, likedPostCount,
+                user.getNickname(), user.getAge(), user.getGender(), year,
+                major.getName(), major.getDepartment(), phoneNumber,
+                writePostCount, commentedPostCount, likedPostCount,
                 user.getUserRole().isAdmin());
     }
 

--- a/src/main/java/com/dku/council/infra/dku/model/StudentInfo.java
+++ b/src/main/java/com/dku/council/infra/dku/model/StudentInfo.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 public class StudentInfo {
     private final String studentName;
     private final String studentId;
+    private final String age;
+    private final String gender;
     private final int yearOfAdmission;
     private final String studentState;
 

--- a/src/test/java/com/dku/council/domain/user/service/DKUAuthServiceTest.java
+++ b/src/test/java/com/dku/council/domain/user/service/DKUAuthServiceTest.java
@@ -74,7 +74,7 @@ class DKUAuthServiceTest {
     @DisplayName("studentInfo를 잘 가져오는지")
     void getStudentInfo() {
         // given
-        DkuUserInfo info = new DkuUserInfo("name", "1212", 0, "state", "", "");
+        DkuUserInfo info = new DkuUserInfo("name", "1212","20", "남자", 0, "state", "", "");
         when(dkuAuthRepository.getAuthPayload(any(),
                 eq(DKU_AUTH_NAME), eq(DkuUserInfo.class), any()))
                 .thenReturn(Optional.of(info));
@@ -121,7 +121,7 @@ class DKUAuthServiceTest {
         String id = "id";
         String pwd = "pwd";
         DkuAuth auth = new DkuAuth(new LinkedMultiValueMap<>());
-        StudentInfo info = new StudentInfo("name", "1212", 0, "state",
+        StudentInfo info = new StudentInfo("name", "1212", "20", "남자",0, "state",
                 "", "");
         RequestDkuStudentDto dto = new RequestDkuStudentDto(id, pwd);
 
@@ -162,7 +162,7 @@ class DKUAuthServiceTest {
         String pwd = "pwd";
         DkuAuth auth = new DkuAuth(new LinkedMultiValueMap<>());
         User user = UserMock.createDummyMajor();
-        StudentInfo info = new StudentInfo("name", "1212", 0, "state",
+        StudentInfo info = new StudentInfo("name", "1212", "20", "남자",0, "state",
                 "major", "department");
         RequestDkuStudentDto dto = new RequestDkuStudentDto(id, pwd);
 
@@ -186,6 +186,8 @@ class DKUAuthServiceTest {
         assertThat(user.getMajor().getDepartment()).isEqualTo(info.getDepartmentName());
         assertThat(user.getYearOfAdmission()).isEqualTo(info.getYearOfAdmission());
         assertThat(user.getAcademicStatus()).isEqualTo(info.getStudentState());
+        assertThat(user.getAge()).isEqualTo(result.getAge());
+        assertThat(user.getGender()).isEqualTo(result.getGender());
 
         verify(userInfoService).invalidateUserInfo(user.getId());
     }

--- a/src/test/java/com/dku/council/domain/user/service/SignupServiceTest.java
+++ b/src/test/java/com/dku/council/domain/user/service/SignupServiceTest.java
@@ -61,7 +61,7 @@ class SignupServiceTest {
     private final String encodedPwd = "Encoded";
     private final String phone = "01011112222";
     private final String studentId = "id";
-    private final DkuUserInfo info = new DkuUserInfo("name", studentId, 0, "재학", "Major", "Department");
+    private final DkuUserInfo info = new DkuUserInfo("name", studentId, "20", "남자", 0, "재학", "Major", "Department");
     private final RequestSignupDto dto = new RequestSignupDto("nickname", "pwd");
 
 
@@ -93,6 +93,8 @@ class SignupServiceTest {
             assertThat(user.getAcademicStatus()).isEqualTo(info.getStudentState());
             assertThat(user.getUserRole()).isEqualTo(UserRole.USER);
             assertThat(user.getMajor()).isEqualTo(major);
+            assertThat(user.getAge()).isEqualTo(info.getAge());
+            assertThat(user.getGender()).isEqualTo(info.getGender());
             return true;
         }));
         verify(dkuAuthService).deleteStudentAuth(token);

--- a/src/test/java/com/dku/council/domain/user/service/UserInfoServiceTest.java
+++ b/src/test/java/com/dku/council/domain/user/service/UserInfoServiceTest.java
@@ -84,6 +84,8 @@ class UserInfoServiceTest {
         assertThat(info.getDepartment()).isEqualTo(user.getMajor().getDepartment());
         assertThat(info.isAdmin()).isEqualTo(user.getUserRole().isAdmin());
         assertThat(info.getPhoneNumber()).isEqualTo(user.getPhone());
+        assertThat(info.getAge()).isEqualTo(user.getAge());
+        assertThat(info.getGender()).isEqualTo(user.getGender());
         assertThat(info.getWritePostCount()).isEqualTo(1);
         assertThat(info.getCommentedPostCount()).isEqualTo(2);
         assertThat(info.getLikedPostCount()).isEqualTo(3);

--- a/src/test/java/com/dku/council/infra/dku/scrapper/DkuStudentServiceTest.java
+++ b/src/test/java/com/dku/council/infra/dku/scrapper/DkuStudentServiceTest.java
@@ -46,6 +46,8 @@ class DkuStudentServiceTest extends AbstractMockServerTest {
         assertThat(studentInfo.getMajorName()).isEqualTo("정치외교학과");
         assertThat(studentInfo.getDepartmentName()).isEqualTo("사회과학대학");
         assertThat(studentInfo.getStudentState()).isEqualTo("재학");
+        assertThat(studentInfo.getAge()).isEqualTo("20");
+        assertThat(studentInfo.getGender()).isEqualTo("남자");
     }
 
     @Test

--- a/src/test/java/com/dku/council/mock/UserInfoMock.java
+++ b/src/test/java/com/dku/council/mock/UserInfoMock.java
@@ -21,6 +21,8 @@ public class UserInfoMock {
                 .nickname("nickname")
                 .yearOfAdmission(2017)
                 .academicStatus(academicStatus)
+                .age("20")
+                .gender("남자")
                 .major(MajorMock.create())
                 .phone("01011112222")
                 .build();

--- a/src/test/java/com/dku/council/mock/UserMock.java
+++ b/src/test/java/com/dku/council/mock/UserMock.java
@@ -65,6 +65,8 @@ public class UserMock {
                 .status(UserStatus.ACTIVE)
                 .role(role)
                 .nickname(NICKNAME)
+                .age("20")
+                .gender("남자")
                 .yearOfAdmission(2017)
                 .academicStatus("재학")
                 .major(major)


### PR DESCRIPTION
### issue 번호

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항
1. 유저 Entity에 나이, 성별 추가
2. 단국대 학생정보 크롤링 시 나이, 성별 추가로 가져오기
3. 내 정보 및 회원가입 등등 학생 정보가 들어가는 전체적인 로직 수정
4. 테스트 코드에 나이, 성별 반영으로 코드 수정