### PR TITLE
feat: CustomHttpStatus를 추가하여 단국대 재학생 인증 오류 시 600으로 처리

### DIFF
--- a/src/main/java/com/dku/council/domain/user/exception/RequiredDkuUpdateException.java
+++ b/src/main/java/com/dku/council/domain/user/exception/RequiredDkuUpdateException.java
@@ -1,11 +1,12 @@
 package com.dku.council.domain.user.exception;
 
+import com.dku.council.global.error.CustomHttpStatus;
 import com.dku.council.global.error.exception.LocalizedMessageException;
 import org.springframework.http.HttpStatus;
 
 public class RequiredDkuUpdateException extends LocalizedMessageException {
 
     public RequiredDkuUpdateException() {
-        super(HttpStatus.NOT_ACCEPTABLE, "required.dku-update");
+        super(CustomHttpStatus.REQUIRED_DKU_UPDATE, "required.dku-update");
     }
 }

--- a/src/main/java/com/dku/council/domain/user/model/entity/User.java
+++ b/src/main/java/com/dku/council/domain/user/model/entity/User.java
@@ -204,6 +204,17 @@ public class User extends BaseEntity {
         this.isDkuChecked = !this.isDkuChecked;
     }
 
+    /**
+     * 단국대 학생 정보를 업데이트합니다.
+     *
+     * @param age      나이
+     * @param gender   성별
+     */
+    public void updateDkuInfo(String age, String gender) {
+        this.isDkuChecked = true;
+        this.age = age;
+        this.gender = gender;
+    }
 
     /**
      * 매년 1월 1일 사용자들의 나이 1을 증가시킵니다.

--- a/src/main/java/com/dku/council/domain/user/service/UserService.java
+++ b/src/main/java/com/dku/council/domain/user/service/UserService.java
@@ -43,7 +43,7 @@ public class UserService {
         User user = userRepository.findByStudentId(dto.getStudentId())
                 .orElseThrow(UserNotFoundException::new);
 
-        if (passwordEncoder.matches(dto.getPassword(), user.getPassword()) && user.isDkuChecked()) {
+        if (passwordEncoder.matches(dto.getPassword(), user.getPassword())) {
             AuthenticationToken token = jwtProvider.issue(user);
             userInfoService.cacheUserInfo(user.getId(), user);
             return new ResponseLoginDto(token);

--- a/src/main/java/com/dku/council/global/error/ControllerAdvisor.java
+++ b/src/main/java/com/dku/council/global/error/ControllerAdvisor.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.MessageSource;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
@@ -35,7 +36,15 @@ public class ControllerAdvisor {
     protected ResponseEntity<ErrorResponseDto> localizedException(LocalizedMessageException e, Locale locale) {
         ErrorResponseDto dto = new ErrorResponseDto(messageSource, locale, e);
         log.error("A problem has occurred in controller advice: [id={}]", dto.getTrackingId(), e);
-        return filter(e, ResponseEntity.status(e.getStatus()).body(dto));
+        return filter(e, ResponseEntity.status(findHttpStatus(e.getStatus())).body(dto));
+    }
+
+    private int findHttpStatus(String status) {
+        if (CustomHttpStatus.valueOf(status) != null) {
+            return CustomHttpStatus.valueOf(status).value();
+        } else {
+            return HttpStatus.valueOf(status).value();
+        }
     }
 
     @ExceptionHandler

--- a/src/main/java/com/dku/council/global/error/CustomHttpStatus.java
+++ b/src/main/java/com/dku/council/global/error/CustomHttpStatus.java
@@ -1,0 +1,99 @@
+package com.dku.council.global.error;
+
+import lombok.Getter;
+import org.springframework.lang.Nullable;
+
+public enum CustomHttpStatus{
+
+    /**
+     * 600 : 단국대학교 학생 인증이 없을 경우
+     */
+    REQUIRED_DKU_UPDATE(600, CustomSeries.DKU_ERROR, "Required DkuInfo");
+
+    private static final CustomHttpStatus[] VALUES;
+
+    static {
+        VALUES = values();
+    }
+
+    private final int value;
+
+    private final CustomSeries series;
+
+    @Getter
+    private final String reasonPhrase;
+
+    CustomHttpStatus(int value, CustomSeries series, String reasonPhrase) {
+        this.value = value;
+        this.series = series;
+        this.reasonPhrase = reasonPhrase;
+    }
+
+    public int value() {
+        return this.value;
+    }
+
+    public CustomSeries series() {
+        return this.series;
+    }
+
+    public String toString() {
+        return this.value + " " + name();
+    }
+
+    public static CustomHttpStatus valueOf(int statusCode) {
+        CustomHttpStatus status = resolve(statusCode);
+        if (status == null) {
+            throw new IllegalArgumentException("No matching constant for [" + statusCode + "]");
+        }
+        return status;
+    }
+
+    @Nullable
+    public static CustomHttpStatus resolve(int statusCode) {
+        for (CustomHttpStatus status : VALUES) {
+            if (status.value == statusCode) {
+                return status;
+            }
+        }
+        return null;
+    }
+
+    public enum CustomSeries {
+        DKU_ERROR(6);
+
+        private final int value;
+
+        CustomSeries(int value) {
+            this.value = value;
+        }
+
+        public int value() {
+            return this.value;
+        }
+
+        @Deprecated
+        public static CustomSeries valueOf(CustomHttpStatus status) {
+            return status.series;
+        }
+
+        public static CustomSeries valueOf(int statusCode) {
+            CustomSeries series = resolve(statusCode);
+            if (series == null) {
+                throw new IllegalArgumentException("No matching constant for [" + statusCode + "]");
+            }
+            return series;
+        }
+
+        @Nullable
+        public static CustomSeries resolve(int statusCode) {
+            int seriesCode = statusCode / 100;
+            for (CustomSeries series : values()) {
+                if (series.value == seriesCode) {
+                    return series;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/dku/council/global/error/ErrorResponseDto.java
+++ b/src/main/java/com/dku/council/global/error/ErrorResponseDto.java
@@ -14,7 +14,8 @@ import java.util.UUID;
 public class ErrorResponseDto {
     private final String timestamp;
     private final String trackingId;
-    private final HttpStatus status;
+    private final int statusCode;
+    private final String status;
     private final String code;
     private final List<Object> message;
 
@@ -22,6 +23,7 @@ public class ErrorResponseDto {
     public ErrorResponseDto(MessageSource messageSource, Locale locale, LocalizedMessageException e) {
         this.timestamp = LocalDateTime.now().toString();
         this.trackingId = UUID.randomUUID().toString();
+        this.statusCode = e.getStatusCode();
         this.status = e.getStatus();
         this.code = e.getCode();
         this.message = e.getMessages(messageSource, locale);

--- a/src/main/java/com/dku/council/global/error/ExceptionHandlerFilter.java
+++ b/src/main/java/com/dku/council/global/error/ExceptionHandlerFilter.java
@@ -38,7 +38,7 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
     private void writeErrorResponse(HttpServletResponse response, Locale locale, LocalizedMessageException ex) throws IOException {
         ErrorResponseDto dto = new ErrorResponseDto(messageSource, locale, ex);
         log.error("A problem has occurred in filter: [id={}]", dto.getTrackingId(), ex);
-        writeResponse(response, dto, ex.getStatus().value());
+        writeResponse(response, dto, Integer.parseInt(ex.getCode()));
     }
 
     private void writeUnexpectedErrorResponse(HttpServletResponse response, Locale locale, Exception ex) throws IOException {

--- a/src/main/java/com/dku/council/global/error/exception/LocalizedMessageException.java
+++ b/src/main/java/com/dku/council/global/error/exception/LocalizedMessageException.java
@@ -1,5 +1,6 @@
 package com.dku.council.global.error.exception;
 
+import com.dku.council.global.error.CustomHttpStatus;
 import lombok.Getter;
 import org.springframework.context.MessageSource;
 import org.springframework.http.HttpStatus;
@@ -11,21 +12,32 @@ import java.util.Objects;
 @Getter
 public class LocalizedMessageException extends RuntimeException {
 
-    private final HttpStatus status;
+    private final int code;
+    private final String status;
     private final String messageId;
     private final Object[] arguments;
     private String customMessage = null;
 
     public LocalizedMessageException(HttpStatus status, String messageId, Object... arguments) {
         super(formatMessage(messageId, arguments));
-        this.status = status;
+        this.code = status.value();
+        this.status = status.name();
         this.messageId = messageId;
         this.arguments = arguments;
     }
 
     public LocalizedMessageException(Throwable cause, HttpStatus status, String messageId, Object... arguments) {
         super(formatMessage(messageId, arguments), cause);
-        this.status = status;
+        this.code = status.value();
+        this.status = status.name();
+        this.messageId = messageId;
+        this.arguments = arguments;
+    }
+
+    public LocalizedMessageException(CustomHttpStatus status, String messageId, Object... arguments) {
+        super(formatMessage(messageId, arguments));
+        this.code = status.value();
+        this.status = status.name();
         this.messageId = messageId;
         this.arguments = arguments;
     }
@@ -44,6 +56,10 @@ public class LocalizedMessageException extends RuntimeException {
 
     public String getCode() {
         return getClass().getSimpleName();
+    }
+
+    public int getStatusCode() {
+        return this.code;
     }
 
     public static LocalizedMessageException of(Exception e) {

--- a/src/main/java/com/dku/council/infra/dku/service/DkuAuthBatchService.java
+++ b/src/main/java/com/dku/council/infra/dku/service/DkuAuthBatchService.java
@@ -46,7 +46,7 @@ public class DkuAuthBatchService {
         if (info.getStudentState().equals("재학")) {
             User user = userRepository.findByStudentId(dto.getDkuStudentId())
                     .orElseThrow(UserNotFoundException::new);
-            user.changeIsDkuChecked();
+            user.updateDkuInfo(info.getAge(), info.getGender());
         }
         else {
             throw new FailedAuthRefreshException();


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항
1. 단국대 재학생 인증 오류 시 http 상태 코드 600으로 처리
