### PR TITLE
fix: CustomHttpStatus가 아닐 때 오류 로그가 뜨지 않는 버그 수정

### DIFF
--- a/src/main/java/com/dku/council/global/error/ControllerAdvisor.java
+++ b/src/main/java/com/dku/council/global/error/ControllerAdvisor.java
@@ -36,15 +36,19 @@ public class ControllerAdvisor {
     protected ResponseEntity<ErrorResponseDto> localizedException(LocalizedMessageException e, Locale locale) {
         ErrorResponseDto dto = new ErrorResponseDto(messageSource, locale, e);
         log.error("A problem has occurred in controller advice: [id={}]", dto.getTrackingId(), e);
-        return filter(e, ResponseEntity.status(findHttpStatus(e.getStatus())).body(dto));
+        if (containsEnum(e.getStatus())) {
+            return filter(e, ResponseEntity.status(e.getStatusCode()).body(dto));
+        }
+        return filter(e, ResponseEntity.status(HttpStatus.valueOf(e.getStatus())).body(dto));
     }
 
-    private int findHttpStatus(String status) {
-        if (CustomHttpStatus.valueOf(status) != null) {
-            return CustomHttpStatus.valueOf(status).value();
-        } else {
-            return HttpStatus.valueOf(status).value();
+    private boolean containsEnum(String constantName) {
+        for (CustomHttpStatus status : CustomHttpStatus.VALUES) {
+            if (status.name().equals(constantName)) {
+                return true;
+            }
         }
+        return false;
     }
 
     @ExceptionHandler

--- a/src/main/java/com/dku/council/global/error/CustomHttpStatus.java
+++ b/src/main/java/com/dku/council/global/error/CustomHttpStatus.java
@@ -10,7 +10,7 @@ public enum CustomHttpStatus{
      */
     REQUIRED_DKU_UPDATE(600, CustomSeries.DKU_ERROR, "Required DkuInfo");
 
-    private static final CustomHttpStatus[] VALUES;
+    public static final CustomHttpStatus[] VALUES;
 
     static {
         VALUES = values();

--- a/src/test/java/com/dku/council/global/error/ErrorResponseDtoTest.java
+++ b/src/test/java/com/dku/council/global/error/ErrorResponseDtoTest.java
@@ -38,6 +38,6 @@ class ErrorResponseDtoTest {
         DateTimeFormatter.ISO_DATE_TIME.parse(dto.getTimestamp());
         assertThat(dto.getCode()).isEqualTo("LocalizedMessageException");
         assertThat(dto.getMessage()).isEqualTo(List.of("localizedMessage"));
-        assertThat(dto.getStatus()).isEqualTo(HttpStatus.OK);
+        assertThat(dto.getStatus()).isEqualTo(HttpStatus.OK.name());
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항
1. CustomHttpStatus 관련된 오류 수정
