### PR TITLE
feat: 내 정보 조회 시 재학생 여부 확인할 수 있는 값 추가

### DIFF
--- a/src/main/java/com/dku/council/domain/user/model/dto/response/ResponseUserInfoDto.java
+++ b/src/main/java/com/dku/council/domain/user/model/dto/response/ResponseUserInfoDto.java
@@ -22,5 +22,6 @@ public class ResponseUserInfoDto {
     private final Long likedPostCount;
     private final Long petitionCount;
     private final Long agreedPetitionCount;
+    private final boolean isDkuChecked;
     private final boolean admin;
 }

--- a/src/main/java/com/dku/council/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/dku/council/domain/user/repository/UserRepository.java
@@ -47,8 +47,8 @@ public interface UserRepository extends JpaRepository<User, Long>, JpaSpecificat
     Optional<User> findByIdWithNotActive(@Param("id") Long id);
 
     /**
-     * 학기 단위 (3.1, 9.1)로 계정 인증을 false로 변경할 때 사용한다.
+     * 학기 단위 (3.1, 9.1)로 계정 인증을 false로 변경할 때 사용한다. (단, 관리자는 제외한다.)
      */
-    @Query("select u from User u where u.status = 'ACTIVE' and u.isDkuChecked = true")
-    List<User> findAllWithDkuChecked();
+    @Query("select u from User u where u.status = 'ACTIVE' and u.isDkuChecked = true and u.userRole != 'ADMIN'")
+    List<User> findAllWithDkuCheckedExceptAdmin();
 }

--- a/src/main/java/com/dku/council/domain/user/service/UserInfoService.java
+++ b/src/main/java/com/dku/council/domain/user/service/UserInfoService.java
@@ -48,7 +48,7 @@ public class UserInfoService {
                 user.getNickname(), user.getAge(), user.getGender(), year,
                 major.getName(), major.getDepartment(), phoneNumber, user.getProfileImage(),
                 writePostCount, commentedPostCount, likedPostCount,
-                petitionCount, agreedPetitionCount, user.getUserRole().isAdmin());
+                petitionCount, agreedPetitionCount, user.isDkuChecked(), user.getUserRole().isAdmin());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/dku/council/infra/dku/service/DkuAuthBatchService.java
+++ b/src/main/java/com/dku/council/infra/dku/service/DkuAuthBatchService.java
@@ -31,7 +31,7 @@ public class DkuAuthBatchService {
      */
     @Transactional
     public void resetDkuAuth() {
-        List<User> listUser = userRepository.findAllWithDkuChecked();
+        List<User> listUser = userRepository.findAllWithDkuCheckedExceptAdmin();
         for (User user : listUser) {
             user.changeIsDkuChecked();
         }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항
1. 내 정보 조회 API 호출 시 단국대학교 재학생 인증 여부를 알 수 있도록 값 추가
- boolean 타입의 isDkuChecked 로 확인 가능
