### PR TITLE
feat: 한글 이름 파일 다운로드 시, ASCII 문자만 포함하는 Content-Disposition 헤더쪽 오류 발생으로 수정

### DIFF
--- a/src/main/java/com/dku/council/infra/nhn/s3/service/ObjectDownloadService.java
+++ b/src/main/java/com/dku/council/infra/nhn/s3/service/ObjectDownloadService.java
@@ -2,11 +2,11 @@ package com.dku.council.infra.nhn.s3.service;
 
 import com.dku.council.infra.nhn.global.service.service.NHNAuthService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 @Service
@@ -21,13 +21,14 @@ public class ObjectDownloadService {
         HttpHeaders headers = new HttpHeaders();
         headers.add("X-Auth-Token", nhnAuthService.requestToken());
         headers.setAccept(List.of(MediaType.APPLICATION_OCTET_STREAM));
-        headers.setContentDispositionFormData("attachment", fileName);
+        // 파일 이름을 UTF-8로 인코딩하여 Content-Disposition 헤더에 추가
+        String encodedFileName = new String(fileName.getBytes(StandardCharsets.UTF_8), StandardCharsets.ISO_8859_1);
+        headers.setContentDispositionFormData("attachment", encodedFileName);
 
         return webClient.get()
                 .uri(fileUrl)
                 .headers(httpHeaders -> httpHeaders.addAll(headers))
-                .exchangeToMono(value -> value.toEntity(new ParameterizedTypeReference<byte[]>() {
-                }))
+                .exchangeToMono(response -> response.toEntity(byte[].class))
                 .block();
     }
     


### PR DESCRIPTION
### issue 번호

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항
한글 이름 파일 다운로드 시, ASCII 문자만 포함하는 Content-Disposition 헤더쪽 오류 발생으로 수정
