### PR TITLE
feat: 단터디, 베어이츠, 단혼밥 게시글 채팅방과 연결

### DIFF
--- a/src/main/java/com/dku/council/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/dku/council/domain/chat/controller/ChatRoomController.java
@@ -104,8 +104,9 @@ public class ChatRoomController {
      * @param roomId        채팅방 id
      */
     @DeleteMapping
+    @ResponseBody
     @UserAuth
-    public String delChatRoom(@RequestParam String roomId, AppAuthentication auth){
+    public boolean delChatRoom(@RequestParam String roomId, AppAuthentication auth){
 
         // 해당 채팅방에 존재하는 파일들 삭제
         chatFileService.deleteAllFilesInChatRoom(roomId);
@@ -116,7 +117,7 @@ public class ChatRoomController {
         // roomId(UUID 값) 기준으로 채팅방 삭제
         chatService.delChatRoom(auth.getUserId(), roomId, auth.isAdmin());
 
-        return "redirect:/chatRoom";
+        return true;
     }
 
     /**

--- a/src/main/java/com/dku/council/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/dku/council/domain/chat/controller/ChatRoomController.java
@@ -57,7 +57,7 @@ public class ChatRoomController {
                              AppAuthentication auth,
                              RedirectAttributes rttr) {
 
-        ResponseChatRoomDto room = chatService.createChatRoom(name,
+        ResponseChatRoomDto room = chatService.createChatRoomForTest(name,
                 Integer.parseInt(maxUserCount),
                 auth.getUserId());
 

--- a/src/main/java/com/dku/council/domain/chat/model/dto/response/ResponseChatRoomIdDto.java
+++ b/src/main/java/com/dku/council/domain/chat/model/dto/response/ResponseChatRoomIdDto.java
@@ -1,0 +1,10 @@
+package com.dku.council.domain.chat.model.dto.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ResponseChatRoomIdDto {
+    private final String roomId;
+}

--- a/src/main/java/com/dku/council/domain/chat/model/entity/ChatRoom.java
+++ b/src/main/java/com/dku/council/domain/chat/model/entity/ChatRoom.java
@@ -2,6 +2,7 @@ package com.dku.council.domain.chat.model.entity;
 
 import com.dku.council.domain.chat.model.ChatRoomStatus;
 import com.dku.council.domain.user.model.entity.User;
+import com.dku.council.domain.with_dankook.model.entity.WithDankook;
 import com.dku.council.global.base.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -42,6 +43,10 @@ public class ChatRoom extends BaseEntity {
     @NotNull
     private int maxUserCount;
 
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "with_dankook_id")
+    private WithDankook withDankook;
+
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChatRoomUser> users = new ArrayList<>();
 
@@ -49,11 +54,13 @@ public class ChatRoom extends BaseEntity {
     private ChatRoomStatus chatRoomStatus;
 
     @Builder
-    private ChatRoom(@NotNull String roomId,
+    private ChatRoom(WithDankook withDankook,
+                     @NotNull String roomId,
                      @NotNull String roomName,
                      @NotNull int userCount,
                      @NotNull int maxUserCount,
                      User roomManager) {
+        this.withDankook = withDankook;
         this.roomId = roomId;
         this.roomName = roomName;
         this.userCount = userCount;

--- a/src/main/java/com/dku/council/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/dku/council/domain/chat/repository/ChatRoomRepository.java
@@ -24,4 +24,11 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
             "where c.roomId = :roomId and c.roomManager.id = :userId ")
     Optional<ChatRoom> checkChatRoomManagerByUserId(@Param("roomId") String roomId,
                                                     @Param("userId") Long userId);
+
+    /**
+     * 게시글과 채팅방이 1 : 1로 생성 되는 단터디, 베어이츠, 단혼밥에서 사용하는 메소드
+     */
+    @Query("select c from ChatRoom c " +
+            "where c.withDankook.id = :withDankookId and c.chatRoomStatus = 'ACTIVE' ")
+    Optional<ChatRoom> findChatRoomByWithDankookId(@Param("withDankookId") Long withDankookId);
 }

--- a/src/main/java/com/dku/council/domain/chat/service/ChatService.java
+++ b/src/main/java/com/dku/council/domain/chat/service/ChatService.java
@@ -14,8 +14,8 @@ import com.dku.council.global.error.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import javax.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -23,6 +23,7 @@ import java.util.UUID;
 @Service
 @RequiredArgsConstructor
 @Slf4j
+@Transactional(readOnly = true)
 public class ChatService {
 
     private final ChatRoomRepository chatRoomRepository;
@@ -73,6 +74,7 @@ public class ChatService {
      * @param userId            채팅방을 생성하고자 하는 사용자 id
      * @return                  채팅방 정보
      */
+    @Transactional
     public void createChatRoom(WithDankook withDankook, String roomName, int maxUserCount, Long userId){
         // roomName 와 roomPwd 로 chatRoom 빌드 후 return
 
@@ -97,6 +99,7 @@ public class ChatService {
      * @param userId            채팅방을 생성하고자 하는 사용자 id
      * @return                  채팅방 정보
      */
+    @Transactional
     public ResponseChatRoomDto createChatRoomForTest(String roomName, int maxUserCount, Long userId){
         // roomName 와 roomPwd 로 chatRoom 빌드 후 return
 

--- a/src/main/java/com/dku/council/domain/chat/service/ChatService.java
+++ b/src/main/java/com/dku/council/domain/chat/service/ChatService.java
@@ -8,6 +8,7 @@ import com.dku.council.domain.chat.repository.ChatRoomRepository;
 import com.dku.council.domain.chat.repository.ChatRoomUserRepository;
 import com.dku.council.domain.user.model.entity.User;
 import com.dku.council.domain.user.repository.UserRepository;
+import com.dku.council.domain.with_dankook.model.entity.WithDankook;
 import com.dku.council.global.error.exception.NotGrantedException;
 import com.dku.council.global.error.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -72,7 +73,31 @@ public class ChatService {
      * @param userId            채팅방을 생성하고자 하는 사용자 id
      * @return                  채팅방 정보
      */
-    public ResponseChatRoomDto createChatRoom(String roomName, int maxUserCount, Long userId){
+    public void createChatRoom(WithDankook withDankook, String roomName, int maxUserCount, Long userId){
+        // roomName 와 roomPwd 로 chatRoom 빌드 후 return
+
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+
+        ChatRoom chatRoom = ChatRoom.builder()
+                .withDankook(withDankook)
+                .roomId(UUID.randomUUID().toString())
+                .roomName(roomName)
+                .roomManager(user) // 채팅방 방장
+                .userCount(0) // 채팅방 참여 인원수
+                .maxUserCount(maxUserCount) // 최대 인원수 제한
+                .build();
+        chatRoomRepository.save(chatRoom);
+    }
+
+    /**
+     * 채팅방 생성 (프론트 화면 확인용. with-Dankook이랑 연결 안되어있음)
+     *
+     * @param roomName          생성할 채팅방의 이름
+     * @param maxUserCount      생성할 채팅방의 최대 인원수 제한
+     * @param userId            채팅방을 생성하고자 하는 사용자 id
+     * @return                  채팅방 정보
+     */
+    public ResponseChatRoomDto createChatRoomForTest(String roomName, int maxUserCount, Long userId){
         // roomName 와 roomPwd 로 chatRoom 빌드 후 return
 
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);

--- a/src/main/java/com/dku/council/domain/with_dankook/controller/BearEatsController.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/controller/BearEatsController.java
@@ -1,5 +1,6 @@
 package com.dku.council.domain.with_dankook.controller;
 
+import com.dku.council.domain.chat.model.dto.response.ResponseChatRoomIdDto;
 import com.dku.council.domain.post.model.dto.response.ResponsePage;
 import com.dku.council.domain.user.service.UserService;
 import com.dku.council.domain.with_dankook.model.dto.list.SummarizedBearEatsDto;
@@ -89,9 +90,9 @@ public class BearEatsController {
      */
     @PostMapping("/{id}/enter")
     @UserAuth
-    public void enter(AppAuthentication auth, @PathVariable @Valid Long id) {
+    public ResponseChatRoomIdDto enter(AppAuthentication auth, @PathVariable @Valid Long id) {
         userService.isDkuChecked(auth.getUserId());
-        bearEatsService.enter(id, auth.getUserId(), auth.getUserRole());
+        return bearEatsService.enter(id, auth.getUserId(), auth.getUserRole());
     }
 
     /**

--- a/src/main/java/com/dku/council/domain/with_dankook/controller/EatingAloneController.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/controller/EatingAloneController.java
@@ -1,5 +1,6 @@
 package com.dku.council.domain.with_dankook.controller;
 
+import com.dku.council.domain.chat.model.dto.response.ResponseChatRoomIdDto;
 import com.dku.council.domain.post.model.dto.response.ResponsePage;
 import com.dku.council.domain.user.service.UserService;
 import com.dku.council.domain.with_dankook.model.dto.list.SummarizedEatingAloneDto;
@@ -89,10 +90,10 @@ public class EatingAloneController {
      */
     @PostMapping("/{id}/enter")
     @UserAuth
-    public void enter(AppAuthentication auth,
-                       @PathVariable @Valid Long id) {
+    public ResponseChatRoomIdDto enter(AppAuthentication auth,
+                                       @PathVariable @Valid Long id) {
         userService.isDkuChecked(auth.getUserId());
-        eatingAloneService.enter(id, auth.getUserId(), auth.getUserRole());
+        return eatingAloneService.enter(id, auth.getUserId(), auth.getUserRole());
     }
 
     /**

--- a/src/main/java/com/dku/council/domain/with_dankook/controller/StudyController.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/controller/StudyController.java
@@ -1,5 +1,6 @@
 package com.dku.council.domain.with_dankook.controller;
 
+import com.dku.council.domain.chat.model.dto.response.ResponseChatRoomIdDto;
 import com.dku.council.domain.post.model.dto.response.ResponsePage;
 import com.dku.council.domain.user.service.UserService;
 import com.dku.council.domain.with_dankook.model.dto.list.SummarizedStudyDto;
@@ -100,14 +101,20 @@ public class StudyController {
 
     /**
      * 단터디 게시글 신청
+     * <p>
+     *     프론트에서 성공적으로 roomId를 받는다면, </br>
+     *     사용자를 게시글에 해당하는 채팅방에 입장시켜야 하므로 </br>
+     *     바로 /pub/chat/enterUser에 roomId를 포함한 request 양식에 맞춰 요청을 보내줘야합니다. </br>
+     * </p>
      *
-     * @param id   게시글 id
+     * @param id        게시글 id
+     * @return roomId   해당 게시글에 대한 채팅방 roomId
      */
     @PostMapping("/{id}/enter")
     @UserAuth
-    public void enter(AppAuthentication auth, @PathVariable @Valid Long id) {
+    public ResponseChatRoomIdDto enter(AppAuthentication auth, @PathVariable @Valid Long id) {
         userService.isDkuChecked(auth.getUserId());
-        studyService.enter(id, auth.getUserId(), auth.getUserRole());
+        return studyService.enter(id, auth.getUserId(), auth.getUserRole());
     }
 
     /**

--- a/src/main/java/com/dku/council/domain/with_dankook/model/dto/request/RequestCreateBearEatsDto.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/model/dto/request/RequestCreateBearEatsDto.java
@@ -5,12 +5,14 @@ import com.dku.council.domain.with_dankook.model.entity.type.BearEats;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
 @Getter
+@RequiredArgsConstructor
 public class RequestCreateBearEatsDto extends RequestCreateWithDankookDto<BearEats>{
 
     @NotNull
@@ -22,23 +24,13 @@ public class RequestCreateBearEatsDto extends RequestCreateWithDankookDto<BearEa
     private final String deliveryPlace;
 
     @NotNull
-    @JsonFormat(pattern = "yyyy-MM-dd HH:MM")
-    @Schema(description = "배달 시간", example = "2023-12-25 17:30")
+    @Schema(description = "배달 시간", example = "2023-12-25 17:30", type = "string")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
     private final LocalDateTime deliveryTime;
 
     @NotBlank
     @Schema(description = "본문", example = "내용")
     private final String content;
-
-    public RequestCreateBearEatsDto(@NotNull String restaurant,
-                                    @NotNull String deliveryPlace,
-                                    @NotNull LocalDateTime deliveryTime,
-                                    @NotBlank String content) {
-        this.restaurant = restaurant;
-        this.deliveryPlace = deliveryPlace;
-        this.deliveryTime = deliveryTime;
-        this.content = content;
-    }
 
     @Override
     public BearEats toEntity(User user) {

--- a/src/main/java/com/dku/council/domain/with_dankook/model/dto/request/RequestCreateEatingAloneDto.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/model/dto/request/RequestCreateEatingAloneDto.java
@@ -4,10 +4,12 @@ import com.dku.council.domain.user.model.entity.User;
 import com.dku.council.domain.with_dankook.model.entity.type.EatingAlone;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 
 @Getter
+@RequiredArgsConstructor
 public class RequestCreateEatingAloneDto extends RequestCreateWithDankookDto<EatingAlone> {
 
     @NotBlank
@@ -17,12 +19,6 @@ public class RequestCreateEatingAloneDto extends RequestCreateWithDankookDto<Eat
     @NotBlank
     @Schema(description = "본문", example = "내용")
     private final String content;
-
-    public RequestCreateEatingAloneDto(@NotBlank String title,
-                                       @NotBlank String content) {
-        this.title = title;
-        this.content = content;
-    }
 
     @Override
     public EatingAlone toEntity(User user) {

--- a/src/main/java/com/dku/council/domain/with_dankook/model/dto/request/RequestCreateStudyDto.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/model/dto/request/RequestCreateStudyDto.java
@@ -2,7 +2,9 @@ package com.dku.council.domain.with_dankook.model.dto.request;
 
 import com.dku.council.domain.user.model.entity.User;
 import com.dku.council.domain.with_dankook.model.entity.type.Study;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
@@ -21,12 +23,12 @@ public class RequestCreateStudyDto extends RequestCreateWithDankookDto<Study> {
     private final int minStudentId;
 
     @NotNull
-    @JsonFormat(pattern = "yyyy-MM-dd HH:MM")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
     @Schema(description = "스터디 시작 시간", example = "2023-12-25 17:30")
     private final LocalDateTime startTime;
 
     @NotNull
-    @JsonFormat(pattern = "yyyy-MM-dd HH:MM")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
     @Schema(description = "스터디 끝나는 시간", example = "2023-12-25 18:30")
     private final LocalDateTime endTime;
 
@@ -37,12 +39,13 @@ public class RequestCreateStudyDto extends RequestCreateWithDankookDto<Study> {
     @Schema(description = "본문", example = "내용")
     private final String content;
 
-    public RequestCreateStudyDto (@NotBlank String title,
-                                  @NotBlank int minStudentId,
-                                  @NotBlank LocalDateTime startTime,
-                                  @NotBlank LocalDateTime endTime,
-                                  String tag,
-                                  @NotBlank String content) {
+    @JsonCreator
+    public RequestCreateStudyDto (@JsonProperty("title") @NotBlank String title,
+                                  @JsonProperty("minStudentId") @NotBlank int minStudentId,
+                                  @JsonProperty("startTime") @NotBlank LocalDateTime startTime,
+                                  @JsonProperty("endTime") @NotBlank LocalDateTime endTime,
+                                  @JsonProperty("tag") String tag,
+                                  @JsonProperty("content") @NotBlank String content) {
         this.title = title;
         this.minStudentId = minStudentId;
         this.startTime = startTime;

--- a/src/main/java/com/dku/council/domain/with_dankook/model/dto/request/RequestCreateStudyDto.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/model/dto/request/RequestCreateStudyDto.java
@@ -23,13 +23,13 @@ public class RequestCreateStudyDto extends RequestCreateWithDankookDto<Study> {
     private final int minStudentId;
 
     @NotNull
+    @Schema(description = "스터디 시작 시간", example = "2023-12-25 17:30", type = "string")
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
-    @Schema(description = "스터디 시작 시간", example = "2023-12-25 17:30")
     private final LocalDateTime startTime;
 
     @NotNull
+    @Schema(description = "스터디 끝나는 시간", example = "2023-12-25 18:30", type = "string")
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
-    @Schema(description = "스터디 끝나는 시간", example = "2023-12-25 18:30")
     private final LocalDateTime endTime;
 
     @Schema(description = "해시태그", example = "자격증")

--- a/src/main/java/com/dku/council/domain/with_dankook/model/entity/WithDankook.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/model/entity/WithDankook.java
@@ -1,5 +1,6 @@
 package com.dku.council.domain.with_dankook.model.entity;
 
+import com.dku.council.domain.chat.model.entity.ChatRoom;
 import com.dku.council.domain.user.model.entity.User;
 import com.dku.council.domain.with_dankook.model.WithDankookStatus;
 import com.dku.council.global.base.BaseEntity;
@@ -35,6 +36,9 @@ public abstract class WithDankook extends BaseEntity {
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "master_user_id")
     private User masterUser;
+
+    @OneToMany(mappedBy = "withDankook", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChatRoom> chatRooms = new ArrayList<>();
 
     @OneToMany(mappedBy = "withDankook", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<WithDankookUser> users = new ArrayList<>();

--- a/src/main/java/com/dku/council/domain/with_dankook/repository/WithDankookUserRepository.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/repository/WithDankookUserRepository.java
@@ -21,19 +21,22 @@ public interface WithDankookUserRepository extends JpaRepository<WithDankookUser
             "where u.withDankook.id = :withDankookId and " +
                     "u.participant.id = :userId and " +
                     "u.participantStatus = 'VALID' ")
-    Optional<WithDankookUser> isExistsByWithDankookIdAndUserId(Long withDankookId, Long userId);
+    Optional<WithDankookUser> isExistsByWithDankookIdAndUserId(@Param("withDankookId") Long withDankookId,
+                                                               @Param("userId") Long userId);
 
     @Query("select u from WithDankookUser u " +
             "where u.withDankook.id = :withDankookId and " +
                     "u.reviewStatus = false and " +
                     "u.participant.id = :userId and " +
                     "u.participantStatus = 'VALID' ")
-    Optional<WithDankookUser> checkReviewStatus(Long withDankookId, Long userId);
+    Optional<WithDankookUser> checkReviewStatus(@Param("withDankookId") Long withDankookId,
+                                                @Param("userId") Long userId);
 
     @Query("select u from WithDankookUser u " +
             "where u.withDankook.id = :withDankookId " +
             "and u.participant.id = :userId ")
-    Optional<WithDankookUser> findByUserIdAndWithDankookId(@Param("userId") Long userId, @Param("withDankookId") Long withDankookId);
+    Optional<WithDankookUser> findByUserIdAndWithDankookId(@Param("userId") Long userId,
+                                                           @Param("withDankookId") Long withDankookId);
 
     @Query("select u from WithDankookUser u " +
             "where u.withDankook.id = :withDankookId and " +

--- a/src/main/java/com/dku/council/domain/with_dankook/service/BearEatsService.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/service/BearEatsService.java
@@ -1,5 +1,8 @@
 package com.dku.council.domain.with_dankook.service;
 
+import com.dku.council.domain.chat.exception.ChatRoomNotFoundException;
+import com.dku.council.domain.chat.model.dto.response.ResponseChatRoomIdDto;
+import com.dku.council.domain.chat.repository.ChatRoomRepository;
 import com.dku.council.domain.chat.service.ChatService;
 import com.dku.council.domain.post.exception.PostCooltimeException;
 import com.dku.council.domain.post.repository.PostTimeMemoryRepository;
@@ -49,6 +52,7 @@ public class BearEatsService {
     private final WithDankookUserRepository withDankookUserRepository;
     private final UserRepository userRepository;
     private final PostTimeMemoryRepository postTimeMemoryRepository;
+    private final ChatRoomRepository chatRoomRepository;
 
     private final Clock clock;
 
@@ -125,8 +129,11 @@ public class BearEatsService {
     }
 
     @Transactional
-    public void enter(Long id, Long userId, UserRole userRole) {
+    public ResponseChatRoomIdDto enter(Long id, Long userId, UserRole userRole) {
+        String roomId = chatRoomRepository.findChatRoomByWithDankookId(id).orElseThrow(ChatRoomNotFoundException::new).getRoomId();
         withDankookService.enter(bearEatsRepository, id, userId, userRole);
+
+        return new ResponseChatRoomIdDto(roomId);
     }
 
     @Transactional

--- a/src/main/java/com/dku/council/domain/with_dankook/service/BearEatsService.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/service/BearEatsService.java
@@ -1,5 +1,6 @@
 package com.dku.council.domain.with_dankook.service;
 
+import com.dku.council.domain.chat.service.ChatService;
 import com.dku.council.domain.post.exception.PostCooltimeException;
 import com.dku.council.domain.post.repository.PostTimeMemoryRepository;
 import com.dku.council.domain.user.model.entity.User;
@@ -42,6 +43,7 @@ public class BearEatsService {
 
     private final WithDankookService<BearEats> withDankookService;
     private final WithDankookUserService withDankookuserSerivce;
+    private final ChatService chatService;
 
     private final BearEatsRepository bearEatsRepository;
     private final WithDankookUserRepository withDankookUserRepository;
@@ -68,6 +70,11 @@ public class BearEatsService {
                         .withDankook(bearEatsRepository.findById(result).orElseThrow(WithDankookNotFoundException::new))
                         .build();
         withDankookUserRepository.save(withDankookuser);
+
+        BearEats bearEats = bearEatsRepository.findById(result).orElseThrow(WithDankookNotFoundException::new);
+
+        // 해당 게시글에 대한 채팅방 생성
+        chatService.createChatRoom(bearEats, dto.getRestaurant(), 4, userId);
 
         postTimeMemoryRepository.put(BEAR_EATS_KEY, userId, writeCooltime, now);
         return result;

--- a/src/main/java/com/dku/council/domain/with_dankook/service/EatingAloneService.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/service/EatingAloneService.java
@@ -1,5 +1,6 @@
 package com.dku.council.domain.with_dankook.service;
 
+import com.dku.council.domain.chat.service.ChatService;
 import com.dku.council.domain.post.exception.PostCooltimeException;
 import com.dku.council.domain.post.repository.PostTimeMemoryRepository;
 import com.dku.council.domain.user.model.entity.User;
@@ -43,6 +44,7 @@ public class EatingAloneService {
 
     private final WithDankookService<EatingAlone> withDankookService;
     private final WithDankookUserService withDankookUserService;
+    private final ChatService chatService;
 
     private final EatingAloneRepository eatingAloneRepository;
     private final WithDankookUserRepository withDankookUserRepository;
@@ -69,6 +71,11 @@ public class EatingAloneService {
                 .withDankook(eatingAloneRepository.findById(result).orElseThrow(WithDankookNotFoundException::new))
                 .build();
         withDankookUserRepository.save(withDankookUser);
+
+        EatingAlone eatingAlone = eatingAloneRepository.findById(result).orElseThrow(WithDankookNotFoundException::new);
+
+        // 해당 게시글에 대한 채팅방 생성
+        chatService.createChatRoom(eatingAlone, dto.getTitle(), 4, userId);
 
         postTimeMemoryRepository.put(EATING_ALONG_KEY, userId, writeCooltime, now);
         return result;

--- a/src/main/java/com/dku/council/domain/with_dankook/service/EatingAloneService.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/service/EatingAloneService.java
@@ -1,5 +1,8 @@
 package com.dku.council.domain.with_dankook.service;
 
+import com.dku.council.domain.chat.exception.ChatRoomNotFoundException;
+import com.dku.council.domain.chat.model.dto.response.ResponseChatRoomIdDto;
+import com.dku.council.domain.chat.repository.ChatRoomRepository;
 import com.dku.council.domain.chat.service.ChatService;
 import com.dku.council.domain.post.exception.PostCooltimeException;
 import com.dku.council.domain.post.repository.PostTimeMemoryRepository;
@@ -50,6 +53,7 @@ public class EatingAloneService {
     private final WithDankookUserRepository withDankookUserRepository;
     private final PostTimeMemoryRepository postTimeMemoryRepository;
     private final UserRepository userRepository;
+    private final ChatRoomRepository chatRoomRepository;
 
     private final Clock clock;
 
@@ -126,8 +130,11 @@ public class EatingAloneService {
     }
 
     @Transactional
-    public void enter(Long id, Long userId, UserRole role) {
+    public ResponseChatRoomIdDto enter(Long id, Long userId, UserRole role) {
+        String roomId = chatRoomRepository.findChatRoomByWithDankookId(id).orElseThrow(ChatRoomNotFoundException::new).getRoomId();
         withDankookService.enter(eatingAloneRepository, id, userId, role);
+
+        return new ResponseChatRoomIdDto(roomId);
     }
 
     @Transactional

--- a/src/main/java/com/dku/council/domain/with_dankook/service/StudyService.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/service/StudyService.java
@@ -2,6 +2,7 @@ package com.dku.council.domain.with_dankook.service;
 
 import com.dku.council.domain.chat.exception.ChatRoomNotFoundException;
 import com.dku.council.domain.chat.model.dto.response.ResponseChatRoomDto;
+import com.dku.council.domain.chat.model.dto.response.ResponseChatRoomIdDto;
 import com.dku.council.domain.chat.model.entity.ChatRoom;
 import com.dku.council.domain.chat.repository.ChatRoomRepository;
 import com.dku.council.domain.chat.service.ChatService;
@@ -48,7 +49,6 @@ import java.util.stream.Collectors;
 @Slf4j
 @Transactional(readOnly = true)
 public class StudyService {
-
     public static final String STUDY_KEY = "study";
 
     private final StudyRepository studyRepository;
@@ -180,14 +180,17 @@ public class StudyService {
     }
 
     @Transactional
-    public void enter(Long id, Long userId, UserRole userRole) {
+    public ResponseChatRoomIdDto enter(Long id, Long userId, UserRole userRole) {
         Study study = findStudy(studyRepository, id, userRole);
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+        String roomId = chatRoomRepository.findChatRoomByWithDankookId(id).orElseThrow(ChatRoomNotFoundException::new).getRoomId();
 
         if (study.getMinStudentId() < Integer.parseInt(String.valueOf(user.getYearOfAdmission()).substring(2))) {
             throw new InvalidMinStudentIdException();
         } else {
             withDankookService.enter(studyRepository, id, userId, userRole);
+
+            return new ResponseChatRoomIdDto(roomId);
         }
     }
 

--- a/src/main/java/com/dku/council/domain/with_dankook/service/StudyService.java
+++ b/src/main/java/com/dku/council/domain/with_dankook/service/StudyService.java
@@ -1,5 +1,10 @@
 package com.dku.council.domain.with_dankook.service;
 
+import com.dku.council.domain.chat.exception.ChatRoomNotFoundException;
+import com.dku.council.domain.chat.model.dto.response.ResponseChatRoomDto;
+import com.dku.council.domain.chat.model.entity.ChatRoom;
+import com.dku.council.domain.chat.repository.ChatRoomRepository;
+import com.dku.council.domain.chat.service.ChatService;
 import com.dku.council.domain.studytag.model.entity.StudyTag;
 import com.dku.council.domain.studytag.repository.StudyTagRepository;
 import com.dku.council.domain.user.model.entity.User;
@@ -51,9 +56,11 @@ public class StudyService {
     private final UserRepository userRepository;
     private final StudyTagRepository studyTagRepository;
     private final WithDankookUserRepository withDankookUserRepository;
+    private final ChatRoomRepository chatRoomRepository;
 
     private final WithDankookService<Study> withDankookService;
     private final WithDankookUserService withDankookUserService;
+    private final ChatService chatService;
 
     private final Clock clock;
 
@@ -68,6 +75,7 @@ public class StudyService {
             throw new StudyCooltimeException("study");
         }
 
+        // 게시글에 작성한 태그 등록
         StudyTag studyTag = retrieveStudyTag(dto.getTag());
 
         Study study = Study.builder()
@@ -87,6 +95,9 @@ public class StudyService {
                 .withDankook(study)
                 .build();
         withDankookUserRepository.save(withDankookUser);
+
+        // 해당 게시글에 대한 채팅방 생성
+        chatService.createChatRoom(study, dto.getTitle(), 4, userId);
 
         withDankookMemoryRepository.put(STUDY_KEY, userId, writeCooltime, now);
         return result;

--- a/src/main/resources/templates/page/chatting/roomlist.html
+++ b/src/main/resources/templates/page/chatting/roomlist.html
@@ -26,7 +26,7 @@
             let $maxUserCount = $("#maxUserCount");
 
             // 모달창 열릴 때 이벤트 처리 => roomId 가져오기
-            $("#enterRoomModal").on("show.bs.modal", function (event) {
+            $("#configRoomModal").on("show.bs.modal", function (event) {
                 roomId = $(event.relatedTarget).data('id');
                 // console.log("roomId: " + roomId);
 
@@ -76,7 +76,7 @@
         function checkRoomManager() {
             $.ajax({
                 type : "get",
-                url : "/confirm/manager/"+roomId,
+                url : "/chatRoom/confirm/manager/"+roomId,
                 async : false,
                 success : function(result){
                     if(!result) {
@@ -96,7 +96,6 @@
                     "roomId": roomId
                 },
                 success : function(result){
-
                     if (result) {
                         alert("채팅방이 삭제되었습니다.");
                         location.href = "/chatRoom";


### PR DESCRIPTION
### issue 번호
#119 
#121 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항
* 게시글 당 하나의 채팅방만 생성되는 단터디, 베어이츠, 단혼밥 서비스에서
  1. 사용자가 게시글 생성 시, 채팅방 생성 추가
  2. 작성자가 아닌 다른 사용자가 특정 게시글 신청 시, 해당 채팅방 roomId 반환하도록 수정
     (이후, 받은 roomId를 가지고 프론트에서 /pub/chat/enterUser로 api 요청하여 입장 메시지와 함께 채팅방에 추가)
* 각종 버그 수정

### 기타
테스트용 채팅방 페이지와 연결해 놓은 컨트롤러 with-dankook가 연동 안되게 createChatRoomForTest로 따로 임시 분리
추후 수정 예정
