### PR TITLE
fix: Redis 연결을 위해 AbstractContainerRedis를 상속

### DIFF
--- a/src/test/java/com/dku/council/domain/oauth/repository/OauthRedisRepositoryTest.java
+++ b/src/test/java/com/dku/council/domain/oauth/repository/OauthRedisRepositoryTest.java
@@ -1,6 +1,8 @@
 package com.dku.council.domain.oauth.repository;
 
 import com.dku.council.domain.oauth.model.dto.request.OauthCachePayload;
+import com.dku.council.util.base.AbstractContainerRedisTest;
+import com.dku.council.util.test.FullIntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,7 +13,8 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
-class OauthRedisRepositoryTest {
+@FullIntegrationTest
+class OauthRedisRepositoryTest extends AbstractContainerRedisTest {
 
     @Autowired
     private OauthRedisRepository oauthRedisRepository;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항
1. removeOAuthCache() 에서 레디스를 사용하기 때문에 클래스 상속 추가
