### PR TITLE
fix : 티켓 전체 조회 로직 추가 및 티켓 조회 시 티켓 이벤트도 같이 조회 가능하게끔 수정

### DIFF
--- a/src/main/java/com/dku/council/domain/post/repository/post/PostRepository.java
+++ b/src/main/java/com/dku/council/domain/post/repository/post/PostRepository.java
@@ -62,5 +62,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             "join PetitionStatistic as ps on p.id = ps.petition.id " +
             "where ps.user.id=:userId and " +
             "p.status='ACTIVE' ")
-    Long countAllAgreedPetitionByUserId(Long userId);
+    Long countAllAgreedPetitionByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/dku/council/domain/ticket/controller/TicketVerifyController.java
+++ b/src/main/java/com/dku/council/domain/ticket/controller/TicketVerifyController.java
@@ -12,6 +12,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Tag(name = "티켓 검증", description = "티켓 검증 관련 API")
 @RestController
 @RequestMapping("/ticket")
@@ -32,6 +34,18 @@ public class TicketVerifyController {
     public ResponseTicketDto myTicket(AppAuthentication auth, @PathVariable Long eventId) {
         userService.isDkuChecked(auth.getUserId());
         return ticketVerifyService.myTicket(auth.getUserId(), eventId);
+    }
+
+    /**
+     * 내 티켓 전체 조회하기
+     * <p>실제로 발급받은 내 티켓을 전체 조회합니다. 내 티켓 조회와 마찬가지로 대상자로 선정되지 않은 경우에는 목록에 포함되지 않습니다.</p>
+     * @return   내 티켓 목록
+     */
+    @GetMapping("/event/my")
+    @UserAuth
+    public List<ResponseTicketDto> myTicketList(AppAuthentication auth) {
+        userService.isDkuChecked(auth.getUserId());
+        return ticketVerifyService.myTicketList(auth.getUserId());
     }
 
     /**

--- a/src/main/java/com/dku/council/domain/ticket/model/dto/response/ResponseTicketDto.java
+++ b/src/main/java/com/dku/council/domain/ticket/model/dto/response/ResponseTicketDto.java
@@ -24,13 +24,17 @@ public class ResponseTicketDto {
     @Schema(description = "예매 순서", example = "5")
     private final int turn;
 
+    @Schema(description = "티켓 이벤트 정보")
+    private final ResponseTicketEventDto event;
+
     public ResponseTicketDto(Long id, String name, String major,
-                             String studentId, boolean issued, int turn) {
+                             String studentId, boolean issued, int turn, ResponseTicketEventDto event) {
         this.id = id;
         this.name = name;
         this.major = major;
         this.studentId = studentId;
         this.issued = issued;
         this.turn = turn;
+        this.event = event;
     }
 }

--- a/src/main/java/com/dku/council/domain/ticket/model/dto/response/ResponseTicketEventDto.java
+++ b/src/main/java/com/dku/council/domain/ticket/model/dto/response/ResponseTicketEventDto.java
@@ -1,0 +1,25 @@
+package com.dku.council.domain.ticket.model.dto.response;
+
+import com.dku.council.domain.ticket.model.entity.TicketEvent;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ResponseTicketEventDto {
+
+    private final String name;
+
+    private final LocalDateTime startAt;
+
+    private final LocalDateTime endAt;
+
+    private final int totalTickets;
+
+    public ResponseTicketEventDto(TicketEvent ticketEvent) {
+        this.name = ticketEvent.getName();
+        this.startAt = ticketEvent.getStartAt();
+        this.endAt = ticketEvent.getEndAt();
+        this.totalTickets = ticketEvent.getTotalTickets();
+    }
+}

--- a/src/main/java/com/dku/council/domain/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/dku/council/domain/ticket/repository/TicketRepository.java
@@ -3,8 +3,11 @@ package com.dku.council.domain.ticket.repository;
 import com.dku.council.domain.ticket.model.entity.Ticket;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
     Optional<Ticket> findByUserIdAndEventId(Long userId, Long eventId);
+
+    List<Ticket> findAllByUserId(Long userId);
 }

--- a/src/test/java/com/dku/council/domain/ticket/controller/TicketVerifyControllerTest.java
+++ b/src/test/java/com/dku/council/domain/ticket/controller/TicketVerifyControllerTest.java
@@ -3,6 +3,7 @@ package com.dku.council.domain.ticket.controller;
 import com.dku.council.domain.ticket.controller.TicketVerifyController;
 import com.dku.council.domain.ticket.model.dto.response.ResponseManagerTicketDto;
 import com.dku.council.domain.ticket.model.dto.response.ResponseTicketDto;
+import com.dku.council.domain.ticket.model.dto.response.ResponseTicketEventDto;
 import com.dku.council.domain.ticket.service.TicketVerifyService;
 import com.dku.council.domain.user.service.UserService;
 import com.dku.council.mock.user.UserAuth;
@@ -43,7 +44,7 @@ class TicketVerifyControllerTest extends AbstractAuthControllerTest {
         // given
         UserAuth.withUser(7L);
         ResponseTicketDto ticket = new ResponseTicketDto(5L, "name",
-                "major", "studentId", false, 4);
+                "major", "studentId", false, 4, null);
 
         when(ticketVerifyService.myTicket(7L, 5L)).thenReturn(ticket);
 
@@ -65,7 +66,7 @@ class TicketVerifyControllerTest extends AbstractAuthControllerTest {
     void getTicketInfo() throws Exception {
         // given
         ResponseTicketDto ticket = new ResponseTicketDto(5L, "name",
-                "major", "studentId", false, 4);
+                "major", "studentId", false, 4, null);
         ResponseManagerTicketDto response = new ResponseManagerTicketDto(ticket, "123456", 1111L);
 
         when(ticketVerifyService.getTicketInfo(5L)).thenReturn(response);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항
1. 티켓 전체 조회 로직 추가
2. 티켓 조회 시 티켓 이벤트도 같이 볼 수 있게끔 수정