### PR TITLE
fix : 라인업 무대 공연 날짜 LocalDateTime으로 변경

### DIFF
--- a/src/main/java/com/dku/council/domain/danfesta/model/dto/request/RequestCreateLineUpDto.java
+++ b/src/main/java/com/dku/council/domain/danfesta/model/dto/request/RequestCreateLineUpDto.java
@@ -23,7 +23,7 @@ public class RequestCreateLineUpDto {
     @Schema(description = "설명", example = "아이유의 공연입니다.")
     private final String description;
 
-    @Schema(description = "공연 날짜", example = "2024-05-20")
+    @Schema(description = "공연 날짜", example = "2024-05-20 18:00")
     private final String performanceDate;
 
     @Schema(description = "축제 일자", example = "FIRST_DAY")

--- a/src/main/java/com/dku/council/domain/danfesta/model/dto/response/ResponseLineUpDto.java
+++ b/src/main/java/com/dku/council/domain/danfesta/model/dto/response/ResponseLineUpDto.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -23,7 +24,7 @@ public class ResponseLineUpDto {
 
     private final String description;
 
-    private final LocalDate performanceTime;
+    private final LocalDateTime performanceTime;
 
     private final FestivalDate festivalDate;
 

--- a/src/main/java/com/dku/council/domain/danfesta/model/entity/LineUp.java
+++ b/src/main/java/com/dku/council/domain/danfesta/model/entity/LineUp.java
@@ -31,7 +31,7 @@ public class LineUp extends BaseEntity {
     @Lob
     private String description;
 
-    private LocalDate performanceTime;
+    private LocalDateTime performanceTime;
 
     @Enumerated(EnumType.STRING)
     private FestivalDate festivalDate;
@@ -39,7 +39,7 @@ public class LineUp extends BaseEntity {
     private boolean isOpened;
 
     @Builder
-    private LineUp(String singer, String description, LocalDate performanceTime, FestivalDate festivalDate, boolean isOpened) {
+    private LineUp(String singer, String description, LocalDateTime performanceTime, FestivalDate festivalDate, boolean isOpened) {
         this.singer = singer;
         this.description = description;
         this.performanceTime = performanceTime;

--- a/src/main/java/com/dku/council/domain/danfesta/service/LineUpService.java
+++ b/src/main/java/com/dku/council/domain/danfesta/service/LineUpService.java
@@ -23,6 +23,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -47,7 +49,7 @@ public class LineUpService {
         LineUp lineUp = LineUp.builder()
                 .singer(dto.getSinger())
                 .description(dto.getDescription())
-                .performanceTime(convertToLocalDate(dto.getPerformanceDate()))
+                .performanceTime(convertToLocalDateTime(dto.getPerformanceDate()))
                 .festivalDate(dto.getFestivalDate())
                 .isOpened(false)
                 .build();
@@ -55,6 +57,11 @@ public class LineUpService {
 
         LineUp result = lineUpRepository.save(lineUp);
         return result.getId();
+    }
+
+    private LocalDateTime convertToLocalDateTime(String performanceDate) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+        return LocalDateTime.parse(performanceDate, formatter);
     }
 
     private void addLineUpImages(LineUp lineUp, List<MultipartFile> dtoImages) {
@@ -76,11 +83,6 @@ public class LineUpService {
         for (LineUpImage image : lineUpImages) {
             image.changeLineUp(lineUp);
         }
-    }
-
-    private LocalDate convertToLocalDate(String performanceDate) {
-        String[] split = performanceDate.split("-");
-        return LocalDate.of(Integer.parseInt(split[0]), Integer.parseInt(split[1]), Integer.parseInt(split[2]));
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/com/dku/council/domain/danfesta/controller/LineUpControllerTest.java
+++ b/src/test/java/com/dku/council/domain/danfesta/controller/LineUpControllerTest.java
@@ -42,8 +42,8 @@ class LineUpControllerTest extends AbstractContainerRedisTest {
     void setup() {
         lineUpRepository.deleteAll();
 
-        notOpenedList = LineUpMock.createList("singer", 3, 2024, 5, 20, FestivalDate.FIRST_DAY, false);
-        openedList = LineUpMock.createList("singer", 3, 2024, 5, 21, FestivalDate.SECOND_DAY, true);
+        notOpenedList = LineUpMock.createList("singer", 3, 2024, 5, 20, 18,0, FestivalDate.FIRST_DAY, false);
+        openedList = LineUpMock.createList("singer", 3, 2024, 5, 21, 18, 0, FestivalDate.SECOND_DAY, true);
         lineUpRepository.saveAll(notOpenedList);
         lineUpRepository.saveAll(openedList);
     }

--- a/src/test/java/com/dku/council/mock/LineUpMock.java
+++ b/src/test/java/com/dku/council/mock/LineUpMock.java
@@ -5,18 +5,19 @@ import com.dku.council.domain.danfesta.model.dto.response.ResponseLineUpDto;
 import com.dku.council.domain.danfesta.model.entity.LineUp;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 public class LineUpMock {
 
-    public static List<LineUp> createList(String prefix, int size, int year, int month, int dayOfMonth, FestivalDate festivalDate, boolean isOpened) {
+    public static List<LineUp> createList(String prefix, int size, int year, int month, int dayOfMonth, int hour, int minute, FestivalDate festivalDate, boolean isOpened) {
         List<LineUp> result = new ArrayList<>();
         for (int i = 0; i < size; i++) {
             LineUp lineUp = LineUp.builder()
                     .singer(prefix + i)
                     .description(prefix + i + " description")
-                    .performanceTime(LocalDate.of(year, month, dayOfMonth))
+                    .performanceTime(LocalDateTime.of(year, month, dayOfMonth, hour, minute))
                     .festivalDate(festivalDate)
                     .isOpened(isOpened)
                     .build();
@@ -27,6 +28,6 @@ public class LineUpMock {
 
     public static ResponseLineUpDto createDummyDto(Long id, FestivalDate festivalDate, boolean isOpened) {
         return new ResponseLineUpDto(id, "singer", new ArrayList<>(), "description",
-                LocalDate.of(2021, 1, 1), festivalDate, isOpened);
+                LocalDateTime.of(2021,1,1,12,0), festivalDate, isOpened);
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항
1. 라인업 무대 공연 날짜 LocalDateTime으로 변경
- String으로 입력받은 데이터를 DateTimeFormatter를 통해 LocalDateTime으로 파싱
