### PR TITLE
feat : 라인업 날짜 조회하는 api 추가

### DIFF
--- a/src/main/java/com/dku/council/domain/danfesta/controller/LineUpController.java
+++ b/src/main/java/com/dku/council/domain/danfesta/controller/LineUpController.java
@@ -2,6 +2,7 @@ package com.dku.council.domain.danfesta.controller;
 
 import com.dku.council.domain.danfesta.model.FestivalDate;
 import com.dku.council.domain.danfesta.model.dto.request.RequestCreateLineUpDto;
+import com.dku.council.domain.danfesta.model.dto.response.ResponseFestivalDateDto;
 import com.dku.council.domain.danfesta.model.dto.response.ResponseLineUpDto;
 import com.dku.council.domain.danfesta.service.LineUpService;
 import com.dku.council.global.auth.jwt.AppAuthentication;
@@ -61,5 +62,13 @@ public class LineUpController {
     @AdminAuth
     public void changeToTrue(AppAuthentication auth, @RequestParam FestivalDate festivalDate) {
         lineUpService.changeToTrue(auth.getUserId(), festivalDate);
+    }
+
+    /**
+     * 라인업 날짜 조회
+     */
+    @GetMapping("/date")
+    public List<ResponseFestivalDateDto> listFestivalDate() {
+        return lineUpService.listFestivalDate();
     }
 }

--- a/src/main/java/com/dku/council/domain/danfesta/model/dto/response/ResponseFestivalDateDto.java
+++ b/src/main/java/com/dku/council/domain/danfesta/model/dto/response/ResponseFestivalDateDto.java
@@ -1,0 +1,18 @@
+package com.dku.council.domain.danfesta.model.dto.response;
+
+import com.dku.council.domain.danfesta.model.entity.LineUp;
+import lombok.Getter;
+
+
+@Getter
+public class ResponseFestivalDateDto {
+
+    private final String performanceTime;
+
+    private final String festivalDate;
+
+    public ResponseFestivalDateDto(LineUp lineup) {
+        this.performanceTime = lineup.getPerformanceTime().toString();
+        this.festivalDate = lineup.getFestivalDate().name();
+    }
+}

--- a/src/main/java/com/dku/council/domain/danfesta/service/LineUpService.java
+++ b/src/main/java/com/dku/council/domain/danfesta/service/LineUpService.java
@@ -2,6 +2,7 @@ package com.dku.council.domain.danfesta.service;
 
 import com.dku.council.domain.danfesta.model.FestivalDate;
 import com.dku.council.domain.danfesta.model.dto.request.RequestCreateLineUpDto;
+import com.dku.council.domain.danfesta.model.dto.response.ResponseFestivalDateDto;
 import com.dku.council.domain.danfesta.model.dto.response.ResponseLineUpDto;
 import com.dku.council.domain.danfesta.model.entity.LineUp;
 import com.dku.council.domain.danfesta.model.entity.LineUpImage;
@@ -120,5 +121,26 @@ public class LineUpService {
             lineUp.changeIsOpened();
             lineUpRepository.save(lineUp);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public List<ResponseFestivalDateDto> listFestivalDate() {
+        List<LineUp> list = lineUpRepository.findAll();
+        List<LineUp> result = new ArrayList<>();
+
+        for(LineUp lineUp : list) {
+            if (result.isEmpty()) {
+                result.add(lineUp);
+            } else {
+                for(LineUp resultLineUp : result) {
+                    if(!resultLineUp.getFestivalDate().equals(lineUp.getFestivalDate())) {
+                        result.add(lineUp);
+                        break;
+                    }
+                }
+            }
+        }
+
+        return result.stream().map(ResponseFestivalDateDto::new).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항
1. 라인업 날짜를 확인하기 위해 공연 날짜와 축제 일차 데이터를 요청하는 API 추가
