### PR TITLE
fix : 라인업 이미지 엔티티에 blurData 필드 추가

### DIFF
--- a/src/main/java/com/dku/council/domain/danfesta/model/dto/LineUpImageDto.java
+++ b/src/main/java/com/dku/council/domain/danfesta/model/dto/LineUpImageDto.java
@@ -23,12 +23,16 @@ public class LineUpImageDto {
     @Schema(description = "이미지 파일 타입", example = "image/jpeg")
     private final String mimeType;
 
+    @Schema(description = "blur 데이터")
+    private final String blurData;
+
     public LineUpImageDto(ObjectUploadContext context, LineUpImage image) {
         this.url = context.getImageUrl(image.getFileId());
         this.originalName = image.getFileName();
 
         String imageMimeType = image.getMimeType();
         this.mimeType = Objects.requireNonNullElse(imageMimeType, MediaType.APPLICATION_OCTET_STREAM_VALUE);
+        this.blurData = image.getBlurData();
     }
 
     public static List<LineUpImageDto> listOf(ObjectUploadContext context, List<LineUpImage> entities) {

--- a/src/main/java/com/dku/council/domain/danfesta/model/entity/LineUpImage.java
+++ b/src/main/java/com/dku/council/domain/danfesta/model/entity/LineUpImage.java
@@ -28,11 +28,15 @@ public class LineUpImage extends BaseEntity {
 
     private String fileName;
 
+    @Lob
+    private String blurData;
+
     @Builder
-    private LineUpImage(String fileId, String mimeType, String fileName) {
+    private LineUpImage(String fileId, String mimeType, String fileName, String blurData) {
         this.fileId = fileId;
         this.mimeType = mimeType;
         this.fileName = fileName;
+        this.blurData = blurData;
     }
 
     public void changeLineUp(LineUp lineUp) {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항
1. 라인업 이미지 엔티티에 blurData 필드 추가
   - 라인업 이미지 해상도 50% 감소, webp 사진을 블러 처리한 후 base64로 인코딩 된 데이터가 들어갈 예정
