### PR TITLE
Refactor: URL-Safe 위해 Base64 URL인코더 사용 및 padding(/,+,=) 제거

### DIFF
--- a/src/main/java/com/dku/council/domain/oauth/util/CodeChallengeConverter.java
+++ b/src/main/java/com/dku/council/domain/oauth/util/CodeChallengeConverter.java
@@ -19,7 +19,7 @@ public class CodeChallengeConverter {
             MessageDigest messageDigest = MessageDigest.getInstance(codeChallengeMethod);
             messageDigest.update(bytes, 0, bytes.length);
             byte[] digest = messageDigest.digest();
-            return Base64.getEncoder().withoutPadding().encodeToString(digest);
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
         } catch (NoSuchAlgorithmException e) {
             throw new NoSuchAlgorithmException(e);
         }

--- a/src/main/java/com/dku/council/domain/oauth/util/CodeChallengeConverter.java
+++ b/src/main/java/com/dku/council/domain/oauth/util/CodeChallengeConverter.java
@@ -12,15 +12,16 @@ public class CodeChallengeConverter {
         return getCodeChallenge(code, codeChallengeMethod);
     }
 
-    private static String getCodeChallenge(String codeVerifier, String codeChallengeMethod) throws NoSuchAlgorithmException {
+    private static String getCodeChallenge(String codeVerifier, String codeChallengeMethod)
+            throws NoSuchAlgorithmException {
         byte[] bytes = codeVerifier.getBytes();
         try {
             MessageDigest messageDigest = MessageDigest.getInstance(codeChallengeMethod);
             messageDigest.update(bytes, 0, bytes.length);
             byte[] digest = messageDigest.digest();
-            return Base64.getEncoder().encodeToString(digest);
+            return Base64.getEncoder().withoutPadding().encodeToString(digest);
         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
+            throw new NoSuchAlgorithmException(e);
         }
     }
 

--- a/src/test/java/com/dku/council/domain/oauth/util/CodeChallengeConverterTest.java
+++ b/src/test/java/com/dku/council/domain/oauth/util/CodeChallengeConverterTest.java
@@ -13,7 +13,7 @@ class CodeChallengeConverterTest {
         CodeChallengeConverter converter = new CodeChallengeConverter();
         String code = "code";
         String codeChallengeMethod = "SHA-256";
-        String expected = "VpTQii5T/8rgwxA+Wtb2B2q9lg6x+KVldwQLwQKPcCs";
+        String expected = "VpTQii5T_8rgwxA-Wtb2B2q9lg6x-KVldwQLwQKPcCs";
 
         String result = converter.convertToCodeChallenge(code, codeChallengeMethod);
 

--- a/src/test/java/com/dku/council/domain/oauth/util/CodeChallengeConverterTest.java
+++ b/src/test/java/com/dku/council/domain/oauth/util/CodeChallengeConverterTest.java
@@ -13,7 +13,7 @@ class CodeChallengeConverterTest {
         CodeChallengeConverter converter = new CodeChallengeConverter();
         String code = "code";
         String codeChallengeMethod = "SHA-256";
-        String expected = "VpTQii5T/8rgwxA+Wtb2B2q9lg6x+KVldwQLwQKPcCs=";
+        String expected = "VpTQii5T/8rgwxA+Wtb2B2q9lg6x+KVldwQLwQKPcCs";
 
         String result = converter.convertToCodeChallenge(code, codeChallengeMethod);
 


### PR DESCRIPTION
### issue 번호
ex) #59

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[] 기능 추가
-[] 기능 삭제
-[v] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항
- URL-Safe 위해 Base64 URL인코더 사용 및 padding(/,+,=) 제거